### PR TITLE
[F] No more issue when creating a customer with a tax id

### DIFF
--- a/src/resources/core/customer.rs
+++ b/src/resources/core/customer.rs
@@ -1,14 +1,14 @@
+use crate::resources::billing::discounts::Discount;
 use crate::resources::billing::subscriptions::Subscription;
 use crate::resources::common::address::Address;
 use crate::resources::common::currency::Currency;
 use crate::resources::common::object::Object;
-use crate::resources::common::path::{UrlPath};
-use crate::resources::paymentmethods::source::{PaymentSource, PaymentSourceParam, Source};
-use crate::util::{Deleted, List, RangeQuery, Expandable};
-use crate::{Client};
-use std::collections::HashMap;
+use crate::resources::common::path::UrlPath;
 use crate::resources::core::customer_taxid::{CustomerTaxID, CustomerTaxIDParam};
-use crate::resources::billing::discounts::Discount;
+use crate::resources::paymentmethods::source::{PaymentSource, PaymentSourceParam, Source};
+use crate::util::{Deleted, Expandable, List, RangeQuery};
+use crate::Client;
+use std::collections::HashMap;
 
 #[derive(Serialize, Deserialize, Debug, PartialEq)]
 pub struct CustomerShipping {
@@ -42,7 +42,7 @@ pub struct Customer {
     pub subscription: Option<List<Subscription>>,
     pub tax_exempt: Option<TaxExempt>,
     pub tax_ids: Option<List<CustomerTaxID>>,
-    pub tax_info: Option<TaxInfo>, //Deprecated
+    pub tax_info: Option<TaxInfo>,                          //Deprecated
     pub tax_info_verification: Option<TaxInfoVerification>, //Deprecated
 }
 
@@ -61,11 +61,11 @@ pub struct CustomFields {
 }
 
 #[derive(Serialize, Deserialize, Debug, PartialEq)]
-#[serde(rename_all="lowercase")]
+#[serde(rename_all = "lowercase")]
 pub enum TaxExempt {
     None,
     Exempt,
-    Reversed
+    Reversed,
 }
 
 #[derive(Serialize, Deserialize, Debug, PartialEq)]
@@ -77,7 +77,7 @@ pub struct TaxInfo {
 
 #[derive(Serialize, Deserialize, Debug, PartialEq)]
 pub struct TaxInfoVerification {
-    pub verified_name: String,
+    pub verified_name: Option<String>,
     pub status: TaxStatus,
 }
 
@@ -126,7 +126,7 @@ pub struct CustomerParam<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub tax_exempt: Option<TaxExempt>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub tax_id_data: Option<CustomerTaxIDParam<'a>>,
+    pub tax_id_data: Option<Vec<CustomerTaxIDParam<'a>>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub expand: Option<Vec<&'a str>>,
 }

--- a/src/resources/core/customer_taxid.rs
+++ b/src/resources/core/customer_taxid.rs
@@ -1,8 +1,8 @@
 use crate::resources::common::object::Object;
-use crate::util::{Expandable, List, Deleted};
-use crate::resources::core::customer::Customer;
-use crate::Client;
 use crate::resources::common::path::UrlPath;
+use crate::resources::core::customer::Customer;
+use crate::util::{Deleted, Expandable, List};
+use crate::Client;
 
 #[derive(Serialize, Deserialize, Debug, PartialEq)]
 pub struct CustomerTaxID {
@@ -12,36 +12,35 @@ pub struct CustomerTaxID {
     pub created: i64,
     pub customer: Expandable<Customer>,
     pub livemode: bool,
-    #[serde(rename="type")]
+    #[serde(rename = "type")]
     pub taxid_type: TaxIDType,
     pub value: String,
     pub verification: TaxIDVerification,
-
 }
 
 #[derive(Serialize, Deserialize, Debug, PartialEq)]
-#[serde(rename_all="snake_case")]
+#[serde(rename_all = "snake_case")]
 pub enum TaxIDType {
     EuVat,
     NzGst,
     AuAbn,
-    Unknown
+    Unknown,
 }
 
 #[derive(Serialize, Deserialize, Debug, PartialEq)]
 pub struct TaxIDVerification {
     pub status: TaxIDVerificationStatus,
     pub verified_address: Option<String>,
-    pub verified_name: Option<String>
+    pub verified_name: Option<String>,
 }
 
 #[derive(Serialize, Deserialize, Debug, PartialEq)]
-#[serde(rename_all="lowercase")]
+#[serde(rename_all = "lowercase")]
 pub enum TaxIDVerificationStatus {
     Pending,
     Unavailable,
     Unverified,
-    Verified
+    Verified,
 }
 
 #[derive(Default, Debug, Serialize, PartialEq)]
@@ -49,6 +48,7 @@ pub struct CustomerTaxIDParam<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub customer: Option<&'a str>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "type")]
     pub taxid_type: Option<TaxIDType>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub value: Option<&'a str>,


### PR DESCRIPTION
This PR fixes 2 things:

- The format of the `tax_id_data` field sent to Stripe's API (Vec instead of single object & field name - cf. #8)
- The `TaxInfoVerification` struct which was not matching exactly the Stripe's API response (verified_name can be null)

Some auto formatting was also done by rustfmt. I can reverse it if it's a big deal but it seems cleaner like this.