### PR TITLE
Tiered amounts based subscriptions

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
+#![recursion_limit="128"]
+
 #[macro_use]
 extern crate serde_derive;
 

--- a/src/resources/billing/plans.rs
+++ b/src/resources/billing/plans.rs
@@ -23,7 +23,7 @@ pub struct Plans {
     pub metadata: HashMap<String, String>,
     pub nickname: Option<String>,
     pub product: Option<Expandable<Products>>,
-    pub tiers: Option<Tiers>,
+    pub tiers: Option<Vec<Tiers>>,
     pub tiers_mode: Option<TiersMode>,
     pub transform_usage: Option<String>,
     pub trial_period_days: Option<i64>,
@@ -41,8 +41,9 @@ pub enum AggregateUsage {
 
 #[derive(Serialize, Deserialize, Debug, PartialEq)]
 pub struct Tiers {
-    pub amount: i64,
-    pub up_to: Option<String>,
+    pub flat_amount: Option<i64>,
+    pub unit_amount: i64,
+    pub up_to: Option<i64>,
 }
 
 #[derive(Serialize, Deserialize, Debug, PartialEq)]

--- a/src/resources/billing/plans.rs
+++ b/src/resources/billing/plans.rs
@@ -13,7 +13,7 @@ pub struct Plans {
     pub object: Object,
     pub active: bool,
     pub aggregate_usage: Option<AggregateUsage>,
-    pub amount: i64,
+    pub amount: Option<i64>,
     pub billing_scheme: Option<BillingScheme>,
     pub created: i64,
     pub currency: Currency,

--- a/src/resources/core/customer_taxid.rs
+++ b/src/resources/core/customer_taxid.rs
@@ -71,21 +71,35 @@ pub struct CustomerTaxIDListParams<'a> {
 }
 
 impl CustomerTaxID {
-
-    pub fn create<B: serde::Serialize>(client: &Client, customer: &str, param: B) -> crate::Result<Self> {
+    pub fn create<B: serde::Serialize>(
+        client: &Client,
+        customer: &str,
+        param: B,
+    ) -> crate::Result<Self> {
         client.post(UrlPath::Customers, vec![customer, "tax_ids"], param)
     }
 
     pub fn retrieve(client: &Client, customer: &str, id: &str) -> crate::Result<Self> {
-        client.get(UrlPath::Customers, vec![customer, "tax_ids", id], serde_json::Map::new())
+        client.get(
+            UrlPath::Customers,
+            vec![customer, "tax_ids", id],
+            serde_json::Map::new(),
+        )
     }
 
     pub fn delete(client: &Client, customer: &str, id: &str) -> crate::Result<Deleted> {
-        client.delete(UrlPath::Customers, vec![customer, "tax_ids", id], serde_json::Map::new())
+        client.delete(
+            UrlPath::Customers,
+            vec![customer, "tax_ids", id],
+            serde_json::Map::new(),
+        )
     }
 
-    pub fn list<B: serde::Serialize>(client: &Client, customer: &str, param: B) -> crate::Result<List<Self>> {
+    pub fn list<B: serde::Serialize>(
+        client: &Client,
+        customer: &str,
+        param: B,
+    ) -> crate::Result<List<Self>> {
         client.get(UrlPath::Customers, vec![customer, "tax_ids"], param)
     }
-
 }


### PR DESCRIPTION
Fixes several things:
- Recursion limit needed to compile on some environment (muslrust based docker for instance)
- `amount` in `Plans` struct can be nil when using tiered amount based subscriptions
- `tiers` should be a `Vec` and some fields are missing in the `Tiers` struct