### PR TITLE
[F] Customer subscription fixed (key was missing a final 's')

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-#![recursion_limit="128"]
+#![recursion_limit = "128"]
 
 #[macro_use]
 extern crate serde_derive;
@@ -18,4 +18,4 @@ use futures::future::Future;
 #[cfg(not(feature = "async"))]
 pub type Result<T> = ::std::result::Result<T, Error>;
 #[cfg(feature = "async")]
-pub type Result<T> = Box<Future<Item=T, Error=Error> + Send>;
+pub type Result<T> = Box<Future<Item = T, Error = Error> + Send>;

--- a/src/resources/core/customer.rs
+++ b/src/resources/core/customer.rs
@@ -39,7 +39,7 @@ pub struct Customer {
     pub preferred_locales: Option<Vec<String>>,
     pub shipping: Option<CustomerShipping>,
     pub sources: Option<List<PaymentSource>>,
-    pub subscription: Option<List<Subscription>>,
+    pub subscriptions: Option<List<Subscription>>,
     pub tax_exempt: Option<TaxExempt>,
     pub tax_ids: Option<List<CustomerTaxID>>,
     pub tax_info: Option<TaxInfo>,                          //Deprecated


### PR DESCRIPTION
The `subscription` field in the `Customer` struct was missing a final 's' in order to be correctly parsed from Stripe.